### PR TITLE
allow links in social of footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
 				<div class="social-icon">
 					<ul class="list-inline">
 						{{ range .Site.Params.footer.socialIcon }}
-						<li><a href="#"><i class="{{ .icon }}"></i></a></li>
+            <li><a href="{{ .url }}"><i class="{{ .icon }}"></i></a></li>
 						{{ end }}
 					</ul>
 				</div>


### PR DESCRIPTION
The social icons do not allow links to the appropriate social site. Adding `.url` let's the developer add a `url = ` to their `config.toml` for the social bits.