### PR TITLE
Fixed a small number of errors and confusion in the social media links

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -98,21 +98,28 @@ custom_css = ["css/custom.css"]
         # social Icons
         [[params.footer.socialIcon]]
         icon = "tf-ion-social-facebook"
+        url = "#"
         
         [[params.footer.socialIcon]]
         icon = "tf-ion-social-twitter"
+        url = "#"
         
         [[params.footer.socialIcon]]
         icon = "tf-ion-social-google-outline"
+        url = "#"
         
         [[params.footer.socialIcon]]
         icon = "tf-ion-social-youtube"
+        url = "#"
         
         [[params.footer.socialIcon]]
         icon = "tf-ion-social-linkedin"
+        url = "#"
         
         [[params.footer.socialIcon]]
         icon = "tf-ion-social-dribbble-outline"
+        url = "#"
         
         [[params.footer.socialIcon]]
         icon = "tf-ion-social-pinterest-outline"
+        url = "#"

--- a/exampleSite/data/team.yml
+++ b/exampleSite/data/team.yml
@@ -8,9 +8,13 @@ teamMember :
     description : Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur necessitatibus ullam, culpa odio.
     socialIcon :
       - icon : tf-ion-social-facebook
+        url : "#"
       - icon : tf-ion-social-twitter
+        url : "#"
       - icon : tf-ion-social-linkedin
+        url : "#"
       - icon : tf-ion-social-dribbble-outline
+        url : "#"
       
   - image : images/team/team-2.jpg
     name : Frank Miller
@@ -18,9 +22,13 @@ teamMember :
     description : Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur necessitatibus ullam, culpa odio.
     socialIcon :
       - icon : tf-ion-social-facebook
+        url : "#"
       - icon : tf-ion-social-twitter
+        url : "#"
       - icon : tf-ion-social-linkedin
+        url : "#"
       - icon : tf-ion-social-dribbble-outline
+        url : "#"
       
   - image : images/team/team-3.jpg
     name : Michael Jonson
@@ -28,9 +36,13 @@ teamMember :
     description : Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur necessitatibus ullam, culpa odio.
     socialIcon :
       - icon : tf-ion-social-facebook
+        url : "#"
       - icon : tf-ion-social-twitter
+        url : "#"
       - icon : tf-ion-social-linkedin
+        url : "#"
       - icon : tf-ion-social-dribbble-outline
+        url : "#"
       
   - image : images/team/team-4.jpg
     name : Mo. Kha. Alamgir
@@ -38,6 +50,10 @@ teamMember :
     description : Lorem ipsum dolor sit amet consectetur adipisicing elit. Aspernatur necessitatibus ullam, culpa odio.
     socialIcon :
       - icon : tf-ion-social-facebook
+        url : "#"
       - icon : tf-ion-social-twitter
+        url : "#"
       - icon : tf-ion-social-linkedin
+        url : "#"
       - icon : tf-ion-social-dribbble-outline
+        url : "#"

--- a/layouts/partials/team.html
+++ b/layouts/partials/team.html
@@ -23,7 +23,7 @@
                         <div class="mask">
                             <ul class="list-inline">
                                 {{ range .socialIcon }}
-                                <li><a href="#"><i class="{{ .icon }}"></i></a></li>
+                                <li><a href="{{ .url }}"><i class="{{ .icon }}"></i></a></li>
                                 {{ end }}
                             </ul>
                         </div>


### PR DESCRIPTION
The footer social media links has been added to the exampleSite/config.toml, such that it does not confuse users where to add these urls.
The team.html the social media urls was set to "#", in the commit it has been fixed, and set to the variable of the url under the team.yml.
In the exampleSite/team.yml the url variable has been set to "#", again to not confuse users about where to add the social media urls belonging to the team