### PR TITLE
Fixes for demo site

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
                     <li class="list-inline-item">{{ .Params.author }}</li>
                     <li class="list-inline-item">{{ dateFormat "Monday, Jan 2, 2006" .Date }}</li>
                 </ul>
-                <img class="img-fluid mb-50" src="{{ .Params.image | absURL }}" alt="blog-image">
+                {{ with .Params.image }}<img class="img-fluid mb-50" src="{{ . | absURL }}" alt="blog-image">{{ end }}
             </div>
             <div class="col-lg-8 offset-lg-2">
                 <div class="post-single-content">

--- a/layouts/partials/blog.html
+++ b/layouts/partials/blog.html
@@ -32,7 +32,7 @@
             {{ end }}
 
             <div class="all-post text-center col-lg-12">
-                <a class="btn btn-main" href="/blog">{{ i18n "viewAllPost" }}</a>
+                <a class="btn btn-main" href="{{ if .Site.GetPage "/blog" }}/blog{{ else }}/posts{{end}}">{{ i18n "viewAllPost" }}</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Demo site has posts instead of blog dir. It also doesn't have images in blog posts.
That should fix both problems. Now img tag should be added only if images are defined and if there is no blog dir, then it should use posts dir (for button View All Post) instead :smile:.