### PR TITLE
add fromspree as suplier for the email

### DIFF
--- a/exampleSite/data/contact.yml
+++ b/exampleSite/data/contact.yml
@@ -6,6 +6,8 @@ content : Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsam, vero,
 enable_maps : false
 mapLatitude : 51.5223477
 mapLongitude: -0.1622023
+provider: formspree
+email: hello@meghna.com
 contactDetails :
   - icon : tf-map-pin
     info : "Khaja Road, Bayzid, Chittagong, Bangladesh"

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -28,8 +28,11 @@
 
             {{"<!-- Contact Form -->" | safeHTML}}
             <div class="col-lg-6 wow fadeInUp" data-wow-duration="500ms" data-wow-delay="300ms">
+            {{ if eq .Site.Data.contact.provider "formspree" }}
+                <form id="contact-form" class="form-meghna" method="post" action="https://formspree.io/{{ .Site.Data.contact.email }}" role="form">
+            {{else}}
                 <form id="contact-form" class="form-meghna" method="post" action="sendmail.php" role="form">
-
+            {{ end }}
                     <input name="e-mail" type="text" id="e-mail" autocomplete="off">
 
                     <div class="form-group">


### PR DESCRIPTION
There is an issue on running and configure `phpmailer` specially if using github pages this is not a posibility. Added a provider option to be able to use fromspree as suplier for email contact. 