### PR TITLE
Skip icon in hero-area if not defined

### DIFF
--- a/layouts/partials/hero-area.html
+++ b/layouts/partials/hero-area.html
@@ -2,9 +2,11 @@
 {{"<!-- Welcome Slider-->" | safeHTML}}
 <section class="hero-area" style='background-image: url("{{ .Site.Params.banner.bgImage | absURL }}");'>
     <div class="block">
+        {{with .Site.Params.banner.icon}}
         <div class="video-button">
-           {{with .Site.Params.banner.icon}} <i class="{{ . }}"></i> {{ end }}
+            <i class="{{ . }}"></i>
         </div>
+        {{ end }}
        {{with .Site.Params.banner.heading}} <h1>{{ . }}</h1>{{ end }}
        {{with .Site.Params.banner.content}} <p>{{ . }}</p> {{ end }}
        {{ if .Site.Params.banner.btn}}


### PR DESCRIPTION
Hi!

Just a quick change to allow to disable the icon in _hero area_ if you want.

To disable the icon, just comment the definition in  `config.toml`:

```
[params.banner]
enable = true
bgImage = "images/slider/interstellar.jpg"
#icon = "tf-ion-play"
heading = "Experience the new reality"
```