### PR TITLE
Correct a problem when using less than 3 blog article

### DIFF
--- a/layouts/partials/blog.html
+++ b/layouts/partials/blog.html
@@ -13,7 +13,7 @@
 			</div>
 			{{"<!-- /section title -->" | safeHTML}}
 
-			{{ range first 3 .Site.RegularPages }}
+			{{ range first 3 (where .Site.RegularPages "Section" "==" "blog")}}
 			{{ .Render "article"}}
 			{{ end }}
 


### PR DESCRIPTION
In this case, the author is (badly) displayed. This patch hard limits blog posts to blog section.