### PR TITLE
Typo

### DIFF
--- a/exampleSite/data/en/skill.yml
+++ b/exampleSite/data/en/skill.yml
@@ -22,5 +22,5 @@ skill:
       percent : 95%
       
     # skill item loop
-    - name :  Andriod Development
+    - name :  Android Development
       percent : 75%

--- a/exampleSite/data/fr/skill.yml
+++ b/exampleSite/data/fr/skill.yml
@@ -22,5 +22,5 @@ skill:
       percent : 95%
       
     # skill item loop
-    - name :  Andriod Development
+    - name :  Android Development
       percent : 75%


### PR DESCRIPTION
There is a typo in this skills part of the page.

Andriod should be Android.