### PR TITLE
Adding background-position: center; to .hero-area in style.css.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -436,6 +436,7 @@ a:hover {
 
 .hero-area {
   background-size: cover;
+  background-position: center;
   height: 100vh;
   position: relative;
   display: flex;


### PR DESCRIPTION
The property background-size: cover; does not fit properly to the size of the background image in small screens because the position of the image is preserved to the left when the viewport is shrinked. Adding background-position: center; fixes this. 

Maybe you haven't noticed this because your example image has the guy align to left, but with images focused in the center, this could be a problem.

![Captura de pantalla de 2020-05-25 19-14-13](https://user-images.githubusercontent.com/45074733/82849129-17e2c800-9ebc-11ea-8c2f-1ae238a04235.png)

![Captura de pantalla de 2020-05-25 19-14-01](https://user-images.githubusercontent.com/45074733/82849127-16190480-9ebc-11ea-8324-5cf58606729e.png)

Please let me know if there is a better way to shrink .hero-area background-image in small screens.  Thanks.