### PR TITLE
i18n for navigation items (fixes #107)

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,37 +42,37 @@ link = "plugins/google-map/map.js"
 
 ############################# Navigation ##################################
 [[menu.main]]
-name = "About Us"
+name = "about"
 URL = "about"
 weight = 1
 
 [[menu.main]]
-name = "Service"
+name = "services"
 URL = "services"
 weight = 2
 
 [[menu.main]]
-name = "Portfolio"
+name = "portfolio"
 URL = "portfolio"
 weight = 3
 
 [[menu.main]]
-name = "Team"
+name = "team"
 URL = "team"
 weight = 4
 
 [[menu.main]]
-name = "Pricing"
+name = "pricing"
 URL = "pricing"
 weight = 5
 
 [[menu.main]]
-name = "Blog"
+name = "blog"
 URL = "blog"
 weight = 6
 
 [[menu.main]]
-name = "Contact"
+name = "contact"
 URL = "contact"
 weight = 7
 

--- a/exampleSite/i18n/en.yaml
+++ b/exampleSite/i18n/en.yaml
@@ -14,3 +14,17 @@
   translation: Submit
 - id: all
   translation: All
+- id: about
+  translation: About Us
+- id: services
+  translation: Service
+- id: portfolio
+  translation: Portfolio
+- id: team
+  translation: Team
+- id: pricing
+  translation: Pricing
+- id: blog
+  translation: Blog
+- id: contact
+  translation: Contact

--- a/exampleSite/i18n/fr.yaml
+++ b/exampleSite/i18n/fr.yaml
@@ -14,3 +14,17 @@
   translation: Soumettre
 - id: all
   translation: All
+- id: about
+  translation: À propos
+- id: services
+  translation: Services
+- id: portfolio
+  translation: Portfolio
+- id: team
+  translation: Équipe
+- id: pricing
+  translation: Tarification
+- id: blog
+  translation: Blog
+- id: contact
+  translation: Contact

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -18,20 +18,20 @@
 					<li class="nav-item"><a class="nav-link" href="#body">{{ .Site.Params.home }}</a></li>
 					{{ if .IsHome }}
 					{{ range .Site.Menus.main }}
-					<li class="nav-item"><a class="nav-link" href="#{{ .URL }}">{{ .Name }}</a></li>
+					<li class="nav-item"><a class="nav-link" href="#{{ .URL }}">{{ i18n .Name }}</a></li>
 					{{ end }}
 
 					{{ else }}
 
 					{{ range .Site.Menus.main }}
-					<li class="nav-item"><a class="nav-link" href="{{ $.Site.BaseURL | relLangURL }}#{{ .URL }}">{{ .Name }}</a>
+					<li class="nav-item"><a class="nav-link" href="{{ $.Site.BaseURL | relLangURL }}#{{ .URL }}">{{ i18n .Name }}</a>
 					</li>
 					{{ end }}
 					{{ end }}
 					
 
 					{{ range .Site.Menus.static }}
-					<li class="nav-item"><a class="nav-link" target="_blank" href="{{ .URL }}">{{ .Name }}</a>
+					<li class="nav-item"><a class="nav-link" target="_blank" href="{{ .URL }}">{{ i18n .Name }}</a>
 					</li>
 					{{ end }}
 					


### PR DESCRIPTION
As requested:
* use the names provided in config.toml as translation ids
* provide translations in the example site
* internationalize the items shown in the navigation bar