### PR TITLE
Migrating analytics.js to gtag.js as Google recommends.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -40,22 +40,3 @@
 {{ "<!-- Main Script -->" | safeHTML }}
 {{ $script := resources.Get "js/script.js" | minify}}
 <script src="{{ $script.Permalink }}"></script>
-
-{{ "<!-- google analytics -->" | safeHTML }}
-{{ with .Site.Params.google_analytics_id }}
-<script>
-  (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r;
-    i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date();
-    a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0];
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m)
-  })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-  ga('create', '{{ . }}', 'auto');
-  ga('send', 'pageview');
-</script>
-{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,4 +25,16 @@
 	<link rel="shortcut icon" href="{{ `images/favicon.png` | absURL }}" type="image/x-icon">
 	<link rel="icon" href="{{ `images/favicon.png` | absURL }}" type="image/x-icon">
 
+	{{ with .Site.Params.google_analytics_id }}
+	{{ "<!-- Global Site Tag (gtag.js) - Google Analytics -->" | safeHTML }}
+	<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
+
+	  gtag('config', '{{ . }}');
+	</script>
+	{{ end }}
+
 </head>


### PR DESCRIPTION
I was reading a little bit of this, and I wonder, why you should wait for do that migration? 

Please take a look to this article:
https://developers.google.com/analytics/devguides/collection/gtagjs/migration?hl=en