### PR TITLE
Fix undefined $site variable

### DIFF
--- a/layouts/partials/map.html
+++ b/layouts/partials/map.html
@@ -5,7 +5,7 @@
 	<div id="map" data-latitude="{{ .map_latitude }}"
 	data-longitude="{{ .map_longitude }}"
 	data-marker="{{ .map_marker | absURL }}"
-	data-marker-name="{{ $site.Title }}"></div>
+	data-marker-name="{{ site.Title }}"></div>
 </div>
 {{ end }}
 {{ end }}

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -24,7 +24,7 @@
 					{{ else }}
 
 					{{ range site.Menus.main }}
-					<li class="nav-item"><a class="nav-link" href="{{ $site.BaseURL | relLangURL }}#{{ .URL }}">{{ i18n .Name }}</a>
+					<li class="nav-item"><a class="nav-link" href="{{ site.BaseURL | relLangURL }}#{{ .URL }}">{{ i18n .Name }}</a>
 					</li>
 					{{ end }}
 					{{ end }}


### PR DESCRIPTION
In https://github.com/themefisher/meghna-hugo/pull/119, a search and replace to move from `.Site` to `site` function introduced a couple of mis-replacements.

The issue is in `map.html` and `navigation.html`, where `$Site` was replaced by `$site` leading to undefined compilation errors.

```
❯ hugo serve --disableFastRender --forceSyncStatic --ignoreCache
Error: add site dependencies: load resources: loading templates: ....
parse failed: template: partials/map.html:8: undefined variable "$site"
sommos.work on  beta [!?] 
❯ hugo serve --disableFastRender --forceSyncStatic --ignoreCache
Error: add site dependencies: load resources: loading templates: ....
parse failed: template: partials/navigation.html:27: undefined variable "$site"
```

This PR replaces `$site` for the `site` function on both cases.