### PR TITLE
resize logo to allow higher resolutions for hidpi displays

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,5 +38,5 @@
 {{ end }}
 
 {{ "<!-- Main Script -->" | safeHTML }}
-{{ $script := resources.Get "js/script.js" | minify | fingerprint "sha384"}
+{{ $script := resources.Get "js/script.js" | minify | fingerprint "sha384"}}
 <script src="{{ $script.Permalink }}" integrity="{{ $script.Data.Integrity }}"></script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,7 +16,7 @@
 				{{"<!-- copyright -->" | safeHTML}}
 				<div class="copyright text-center">
 					<a href="{{ site.Home.Permalink }}">
-						<img src="{{ site.Params.logo | absURL }}" alt="{{ site.Title }}" />
+						<img src="{{ site.Params.logo | absURL }}" alt="{{ site.Title }}" height="42" />
 					</a>
 					<br>
 					<p>{{ site.Params.copyright | markdownify }}</p>

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -3,7 +3,7 @@
 		<nav class="navbar navbar-expand-lg navbar-dark">
 			<a class="navbar-brand p-0" href="{{ .Site.BaseURL | relLangURL }}">
 				{{ if site.Params.logo }}
-				<img class="lozad img-fluid" data-src="{{ site.Params.logo | absURL }}" alt="{{ .Site.Title }}">
+				<img class="lozad img-fluid" data-src="{{ site.Params.logo | absURL }}" alt="{{ .Site.Title }}" height="42">
 				{{ else }}
 				{{ site.Title }}
 				{{ end }}


### PR DESCRIPTION
Using a 42px height logo file is resulting in bad quality on hidpi screens / smartphones. Allowing to use a higher res file and scale it down to 42px in navigation and footer solved it for me. But maybe there is a better way to accomplish this.