### PR TITLE
added config for static link target

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -106,6 +106,10 @@ map_latitude = "51.5223477"
 map_longitude = "-0.1622023"
 map_marker = "images/marker.png"
 
+# navigation
+[params.navigation]
+static_target = "_blank"
+
 ############################# social icons ##########################
 [[params.social]]
 icon = "ti-facebook" # themify icon pack : https://themify.me/themify-icons

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -30,7 +30,7 @@
 					{{ end }}
 
 					{{ range site.Menus.static }}
-					<li class="nav-item"><a class="nav-link" target="_blank" href="{{ .URL }}">{{ i18n .Name }}</a>
+                    <li class="nav-item"><a class="nav-link" target="{{ site.Params.navigation.static_target }}" href="{{ .URL }}">{{ i18n .Name }}</a>
 					</li>
 					{{ end }}
 


### PR DESCRIPTION
added an option in config to allow to choose the target of static (external) links instead of always opening them in a new window/tab (kept the default on _blank)