### PR TITLE
Hide blog section when there is content but no blog posts

### DIFF
--- a/layouts/partials/blog.html
+++ b/layouts/partials/blog.html
@@ -1,4 +1,4 @@
-{{ if gt site.RegularPages 0}}
+{{ if gt (where site.RegularPages "Section" "==" "blog") 0}}
 {{"<!-- Start Blog Section -->" | safeHTML}}
 <section id="blog" class="section">
 	<div class="container">


### PR DESCRIPTION
This fixes an issue when there are no blog posts but other content (such as author posts in the site example) : right now, the blog section still shows, because the condition only checks for `site.RegularPages`, without filtering for blog pages only.

This PR fixes that.